### PR TITLE
Correction pointeur null sur la fonction BottomMember

### DIFF
--- a/Source/DotSpatial.Symbology/LegendItemExt.cs
+++ b/Source/DotSpatial.Symbology/LegendItemExt.cs
@@ -21,7 +21,7 @@ namespace DotSpatial.Symbology
         /// <returns>The found member.</returns>
         public static ILegendItem BottomMember(this ILegendItem self)
         {
-            if (self.LegendItems != null && self.LegendItems.Any())
+            if (self != null && self.LegendItems != null && self.LegendItems.Any())
             {
                 var items = self.LegendItems.ToList();
 


### PR DESCRIPTION
Correction pointeur null non testé causant un crash D4F lorsqu'on essayait de déplacer un layer créé par le "Zoom to Data"